### PR TITLE
allow publishing while handling a DomainEvent

### DIFF
--- a/iddd_common/src/main/java/com/saasovation/common/domain/model/DomainEventPublisher.java
+++ b/iddd_common/src/main/java/com/saasovation/common/domain/model/DomainEventPublisher.java
@@ -36,7 +36,7 @@ public class DomainEventPublisher {
     }
 
     public <T> void publish(final T aDomainEvent) {
-        if (!this.isPublishing() && this.hasSubscribers()) {
+        if (this.hasSubscribers()) {
 
             try {
                 this.setPublishing(true);
@@ -67,18 +67,18 @@ public class DomainEventPublisher {
     }
 
     public void reset() {
-        if (!this.isPublishing()) {
-            this.setSubscribers(null);
-        }
+        this.setSubscribers(null);
     }
 
     @SuppressWarnings("unchecked")
     public <T> void subscribe(DomainEventSubscriber<T> aSubscriber) {
-        if (!this.isPublishing()) {
-            this.ensureSubscribersList();
-
-            this.subscribers().add(aSubscriber);
+        if (this.isPublishing()) {
+            throw new IllegalStateException("cannot subscribe while handling an event");
         }
+
+        this.ensureSubscribersList();
+
+        this.subscribers().add(aSubscriber);
     }
 
     private DomainEventPublisher() {

--- a/iddd_common/src/test/java/com/saasovation/common/event/DomainEventPublisherTest.java
+++ b/iddd_common/src/test/java/com/saasovation/common/event/DomainEventPublisherTest.java
@@ -28,9 +28,12 @@ public class DomainEventPublisherTest extends TestCase {
         super();
     }
 
-    public void testDomainEventPublisherPublish() throws Exception {
+    @Override
+    protected void setUp() throws Exception {
         DomainEventPublisher.instance().reset();
+    }
 
+    public void testDomainEventPublisherPublish() throws Exception {
         DomainEventPublisher.instance().subscribe(new DomainEventSubscriber<TestableDomainEvent>(){
             @Override
             public void handleEvent(TestableDomainEvent aDomainEvent) {
@@ -51,18 +54,15 @@ public class DomainEventPublisherTest extends TestCase {
         assertTrue(this.eventHandled);
     }
 
-    public void testDomainEventPublisherBlocked() throws Exception {
-        DomainEventPublisher.instance().reset();
 
-        DomainEventPublisher.instance().subscribe(new DomainEventSubscriber<TestableDomainEvent>(){
+    public void testCanPublishInEventHandler() throws Exception {
+        DomainEventPublisher.instance().subscribe(new DomainEventSubscriber<TestableDomainEvent>() {
             @Override
             public void handleEvent(TestableDomainEvent aDomainEvent) {
-                assertEquals(100L, aDomainEvent.id());
-                assertEquals("test", aDomainEvent.name());
                 eventHandled = true;
-                // attempt nested publish, which should not work
                 DomainEventPublisher.instance().publish(new AnotherTestableDomainEvent(1000.0));
             }
+
             @Override
             public Class<TestableDomainEvent> subscribedToEventType() {
                 return TestableDomainEvent.class;
@@ -72,7 +72,6 @@ public class DomainEventPublisherTest extends TestCase {
         DomainEventPublisher.instance().subscribe(new DomainEventSubscriber<AnotherTestableDomainEvent>(){
             @Override
             public void handleEvent(AnotherTestableDomainEvent aDomainEvent) {
-                // should never be reached due to blocked publisher
                 assertEquals(1000.0, aDomainEvent.value());
                 anotherEventHandled = true;
             }
@@ -88,6 +87,46 @@ public class DomainEventPublisherTest extends TestCase {
         DomainEventPublisher.instance().publish(new TestableDomainEvent(100L, "test"));
 
         assertTrue(this.eventHandled);
+        assertTrue(this.anotherEventHandled);
+    }
+
+    public void testCannotSubscribeWhenPublishing() throws Exception {
+        final DomainEventSubscriber<AnotherTestableDomainEvent> anotherHandler = new DomainEventSubscriber<AnotherTestableDomainEvent>() {
+            @Override
+            public void handleEvent(AnotherTestableDomainEvent aDomainEvent) {
+                // should never be reached due to incapacitated handler
+                anotherEventHandled = true;
+            }
+
+            @Override
+            public Class<AnotherTestableDomainEvent> subscribedToEventType() {
+                return AnotherTestableDomainEvent.class;
+            }
+        };
+
+        DomainEventPublisher.instance().subscribe(new DomainEventSubscriber<TestableDomainEvent>(){
+            @Override
+            public void handleEvent(TestableDomainEvent aDomainEvent) {
+                eventHandled = true;
+                DomainEventPublisher.instance().subscribe(anotherHandler);
+            }
+            @Override
+            public Class<TestableDomainEvent> subscribedToEventType() {
+                return TestableDomainEvent.class;
+            }
+        });
+
+        try {
+            DomainEventPublisher.instance().publish(new TestableDomainEvent(100L, "test"));
+            fail("the event subscriber should not be allowed to complete as it's trying to modify the publisher's subscribers while handling an event (causing a ConcurrentModificationException)");
+        } catch(IllegalStateException e) {
+            // we're good
+        }
+
+        assertFalse(this.anotherEventHandled);
+
+        DomainEventPublisher.instance().publish(new AnotherTestableDomainEvent(1000.0));
+
         assertFalse(this.anotherEventHandled);
     }
 }


### PR DESCRIPTION
as Vaugh Vernon said in #6 : 

> The DomainEventPublisher must protect itself from the subscribers. For
> example, when a subscriber's handle() method has been called back on, the
> handle() method could attempt to register another subscriber. Even though
> it's all happening on a single thread, that would cause a
> ConcurrentModificationException on the collection.

Nevertheless, it should be possible to publish an event from inside a subsciber's handle() method, to synchronously propagate whatever side effects on the domain the parent DomainEvent handling might produce.